### PR TITLE
🧹 [code health improvement] Remove leftover console.log from auth controller

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,7 +9,6 @@ const client = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const createToken = (_id) => {
   // Check if SECRET is defined
   if (!process.env.SECRET) {
-    console.error('ERROR: JWT SECRET is not defined in environment variables!');
     throw new Error('JWT configuration error');
   }
   


### PR DESCRIPTION
🎯 **What:** Removed an unnecessary `console.error` statement from the `createToken` function in `backend/controllers/authController.js`.
💡 **Why:** When `process.env.SECRET` is missing, an error is immediately thrown right after the console log. Throwing the error already provides a proper stack trace and stops execution, making the manual `console.error` redundant and leading to unnecessary console spam.
✅ **Verification:** Ran syntax checks for the file. Checked for backend tests (none currently exist for auth controllers). Verified that removing the `console` statement does not affect the functional logic of throwing the configuration error.
✨ **Result:** Cleaner logs without redundant error messages when JWT configuration issues occur.

---
*PR created automatically by Jules for task [3071834466656888954](https://jules.google.com/task/3071834466656888954) started by @Srinith2224*