### PR TITLE
🔒 Fix weak PRNG for OAuth Nonce

### DIFF
--- a/backend/services/nutritionService.js
+++ b/backend/services/nutritionService.js
@@ -122,7 +122,7 @@ const searchFood = async (query) => {
         oauth_consumer_key: CONSUMER_KEY,
         oauth_signature_method: 'HMAC-SHA1',
         oauth_timestamp: Math.floor(Date.now() / 1000),
-        oauth_nonce: Math.random().toString(36).substring(2),
+        oauth_nonce: crypto.randomBytes(16).toString('hex'),
         oauth_version: '1.0'
       },
       headers: {
@@ -162,7 +162,7 @@ const getFoodDetails = async (foodId) => {
         oauth_consumer_key: CONSUMER_KEY,
         oauth_signature_method: 'HMAC-SHA1',
         oauth_timestamp: Math.floor(Date.now() / 1000),
-        oauth_nonce: Math.random().toString(36).substring(2),
+        oauth_nonce: crypto.randomBytes(16).toString('hex'),
         oauth_version: '1.0'
       },
       headers: {


### PR DESCRIPTION
🎯 **What:** 
Replaced the use of `Math.random().toString(36).substring(2)` with `crypto.randomBytes(16).toString('hex')` for generating `oauth_nonce` in the `searchFood` and `getFoodDetails` functions within `backend/services/nutritionService.js`.

⚠️ **Risk:** 
`Math.random()` is not a cryptographically secure pseudo-random number generator (CSPRNG). Using it to generate an OAuth nonce makes the nonce predictable. A predictable nonce could allow an attacker to launch replay attacks, potentially leading to unauthorized API access or data manipulation under the context of the compromised session.

🛡️ **Solution:** 
Replaced the weak PRNG with `crypto.randomBytes()`, which is a standard Node.js cryptographically secure method. This ensures that the generated nonces are unpredictable and robust against prediction attacks, properly fulfilling the security requirements of the OAuth 1.0a protocol.

---
*PR created automatically by Jules for task [10481445458707959265](https://jules.google.com/task/10481445458707959265) started by @Srinith2224*